### PR TITLE
uva/uvb clusters

### DIFF
--- a/data/grid5000/sites/sophia/clusters/uva/nodes/uva-1.json
+++ b/data/grid5000/sites/sophia/clusters/uva/nodes/uva-1.json
@@ -44,53 +44,70 @@
     {
       "device": "eth1",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:ba:7a",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth2",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:ba:7c",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth3",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:ba:7e",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0c:eb:1b",
       "interface": "InfiniBand",
       "ip": "172.18.131.1",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uva-1-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0c:eb:1b",
       "interface": "InfiniBand",
       "ip": "172.18.131.1",
       "ip6": "fe80::202:c903:c:eb1b",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uva-1-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.131.1"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.131.1",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -117,10 +134,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "megaraid_sas",
       "interface": "SAS",
       "model": "PERC 6/i",
       "rev": 1.22,
-      "size": 146163105792
+      "size": 146163105792,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -128,7 +147,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uva/nodes/uva-10.json
+++ b/data/grid5000/sites/sophia/clusters/uva/nodes/uva-10.json
@@ -44,53 +44,70 @@
     {
       "device": "eth1",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:c3:60",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth2",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:c3:62",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth3",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:c3:64",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0d:7a:e1",
       "interface": "InfiniBand",
       "ip": "172.18.131.10",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uva-10-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0d:7a:e1",
       "interface": "InfiniBand",
       "ip": "172.18.131.10",
       "ip6": "fe80::202:c903:d:7ae1",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uva-10-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.131.10"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.131.10",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -117,10 +134,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "megaraid_sas",
       "interface": "SAS",
       "model": "PERC 6/i",
       "rev": 1.22,
-      "size": 146163105792
+      "size": 146163105792,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -128,7 +147,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uva/nodes/uva-11.json
+++ b/data/grid5000/sites/sophia/clusters/uva/nodes/uva-11.json
@@ -44,53 +44,70 @@
     {
       "device": "eth1",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:24:e8:5b:43:98",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth2",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:24:e8:5b:43:9a",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth3",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:24:e8:5b:43:9c",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0c:ea:e7",
       "interface": "InfiniBand",
       "ip": "172.18.131.11",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uva-11-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0c:ea:e7",
       "interface": "InfiniBand",
       "ip": "172.18.131.11",
       "ip6": "fe80::202:c903:c:eae7",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uva-11-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.131.11"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.131.11",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -117,10 +134,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "megaraid_sas",
       "interface": "SAS",
       "model": "PERC 6/i",
       "rev": 1.22,
-      "size": 146163105792
+      "size": 146163105792,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -128,7 +147,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uva/nodes/uva-12.json
+++ b/data/grid5000/sites/sophia/clusters/uva/nodes/uva-12.json
@@ -44,53 +44,70 @@
     {
       "device": "eth1",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:ba:85",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth2",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:ba:87",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth3",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:ba:89",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0c:bf:ab",
       "interface": "InfiniBand",
       "ip": "172.18.131.12",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uva-12-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0c:bf:ab",
       "interface": "InfiniBand",
       "ip": "172.18.131.12",
       "ip6": "fe80::202:c903:c:bfab",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uva-12-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.131.12"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.131.12",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -117,10 +134,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "megaraid_sas",
       "interface": "SAS",
       "model": "PERC 6/i",
       "rev": 1.22,
-      "size": 146163105792
+      "size": 146163105792,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -128,7 +147,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uva/nodes/uva-13.json
+++ b/data/grid5000/sites/sophia/clusters/uva/nodes/uva-13.json
@@ -44,53 +44,70 @@
     {
       "device": "eth1",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:24:e8:5b:43:a6",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth2",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:24:e8:5b:43:a8",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth3",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:24:e8:5b:43:aa",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0d:76:21",
       "interface": "InfiniBand",
       "ip": "172.18.131.13",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uva-13-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0d:76:21",
       "interface": "InfiniBand",
       "ip": "172.18.131.13",
       "ip6": "fe80::202:c903:d:7621",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uva-13-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.131.13"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.131.13",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -117,10 +134,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "megaraid_sas",
       "interface": "SAS",
       "model": "PERC 6/i",
       "rev": 1.22,
-      "size": 146163105792
+      "size": 146163105792,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -128,7 +147,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uva/nodes/uva-2.json
+++ b/data/grid5000/sites/sophia/clusters/uva/nodes/uva-2.json
@@ -44,53 +44,70 @@
     {
       "device": "eth1",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:ac:71",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth2",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:ac:73",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth3",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:ac:75",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0d:77:39",
       "interface": "InfiniBand",
       "ip": "172.18.131.2",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uva-2-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0d:77:39",
       "interface": "InfiniBand",
       "ip": "172.18.131.2",
       "ip6": "fe80::202:c903:d:7739",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uva-2-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.131.2"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.131.2",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -117,10 +134,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "megaraid_sas",
       "interface": "SAS",
       "model": "PERC 6/i",
       "rev": 1.22,
-      "size": 146163105792
+      "size": 146163105792,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -128,7 +147,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uva/nodes/uva-3.json
+++ b/data/grid5000/sites/sophia/clusters/uva/nodes/uva-3.json
@@ -44,53 +44,70 @@
     {
       "device": "eth1",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:af:08",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth2",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:af:0a",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth3",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:af:0c",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0d:7a:d1",
       "interface": "InfiniBand",
       "ip": "172.18.131.3",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uva-3-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0d:7a:d1",
       "interface": "InfiniBand",
       "ip": "172.18.131.3",
       "ip6": "fe80::202:c903:d:7ad1",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uva-3-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.131.3"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.131.3",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -117,10 +134,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "megaraid_sas",
       "interface": "SAS",
       "model": "PERC 6/i",
       "rev": 1.22,
-      "size": 146163105792
+      "size": 146163105792,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -128,7 +147,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uva/nodes/uva-4.json
+++ b/data/grid5000/sites/sophia/clusters/uva/nodes/uva-4.json
@@ -44,53 +44,70 @@
     {
       "device": "eth1",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:b6:d5",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth2",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:b6:d7",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth3",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:b6:d9",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0c:eb:2f",
       "interface": "InfiniBand",
       "ip": "172.18.131.4",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uva-4-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0c:eb:2f",
       "interface": "InfiniBand",
       "ip": "172.18.131.4",
       "ip6": "fe80::202:c903:c:eb2f",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uva-4-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.131.4"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.131.4",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -117,10 +134,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "megaraid_sas",
       "interface": "SAS",
       "model": "PERC 6/i",
       "rev": 1.22,
-      "size": 146163105792
+      "size": 146163105792,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -128,7 +147,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uva/nodes/uva-5.json
+++ b/data/grid5000/sites/sophia/clusters/uva/nodes/uva-5.json
@@ -44,53 +44,70 @@
     {
       "device": "eth1",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:ac:54",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth2",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:ac:56",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth3",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:ac:58",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0c:ea:ff",
       "interface": "InfiniBand",
       "ip": "172.18.131.5",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uva-5-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0c:ea:ff",
       "interface": "InfiniBand",
       "ip": "172.18.131.5",
       "ip6": "fe80::202:c903:c:eaff",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uva-5-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.131.5"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.131.5",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -117,10 +134,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "megaraid_sas",
       "interface": "SAS",
       "model": "PERC 6/i",
       "rev": 1.22,
-      "size": 146163105792
+      "size": 146163105792,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -128,7 +147,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uva/nodes/uva-6.json
+++ b/data/grid5000/sites/sophia/clusters/uva/nodes/uva-6.json
@@ -44,53 +44,70 @@
     {
       "device": "eth1",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:24:e8:5b:45:58",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth2",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:24:e8:5b:45:5a",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth3",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:24:e8:5b:45:5c",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0d:77:31",
       "interface": "InfiniBand",
       "ip": "172.18.131.6",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uva-6-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0d:77:31",
       "interface": "InfiniBand",
       "ip": "172.18.131.6",
       "ip6": "fe80::202:c903:d:7731",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uva-6-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.131.6"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.131.6",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -117,10 +134,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "megaraid_sas",
       "interface": "SAS",
       "model": "PERC 6/i",
       "rev": 1.22,
-      "size": 146163105792
+      "size": 146163105792,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -128,7 +147,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uva/nodes/uva-7.json
+++ b/data/grid5000/sites/sophia/clusters/uva/nodes/uva-7.json
@@ -44,53 +44,70 @@
     {
       "device": "eth1",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:a4:aa",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth2",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:a4:ac",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth3",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:a4:ae",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0d:77:3d",
       "interface": "InfiniBand",
       "ip": "172.18.131.7",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uva-7-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0d:77:3d",
       "interface": "InfiniBand",
       "ip": "172.18.131.7",
       "ip6": "fe80::202:c903:d:773d",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uva-7-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.131.7"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.131.7",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -117,10 +134,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "megaraid_sas",
       "interface": "SAS",
       "model": "PERC 6/i",
       "rev": 1.22,
-      "size": 146163105792
+      "size": 146163105792,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -128,7 +147,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uva/nodes/uva-8.json
+++ b/data/grid5000/sites/sophia/clusters/uva/nodes/uva-8.json
@@ -44,53 +44,70 @@
     {
       "device": "eth1",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:b1:ff",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth2",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:b2:01",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth3",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:b2:03",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0d:77:45",
       "interface": "InfiniBand",
       "ip": "172.18.131.8",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uva-8-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0d:77:45",
       "interface": "InfiniBand",
       "ip": "172.18.131.8",
       "ip6": "fe80::202:c903:d:7745",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uva-8-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.131.8"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.131.8",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -117,10 +134,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "megaraid_sas",
       "interface": "SAS",
       "model": "PERC 6/i",
       "rev": 1.22,
-      "size": 146163105792
+      "size": 146163105792,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -128,7 +147,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uva/nodes/uva-9.json
+++ b/data/grid5000/sites/sophia/clusters/uva/nodes/uva-9.json
@@ -44,53 +44,70 @@
     {
       "device": "eth1",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:af:38",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth2",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:af:3a",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "eth3",
       "driver": "bnx2",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:b9:55:af:3c",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0d:7c:e9",
       "interface": "InfiniBand",
       "ip": "172.18.131.9",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uva-9-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:02:c9:03:00:0d:7c:e9",
       "interface": "InfiniBand",
       "ip": "172.18.131.9",
       "ip6": "fe80::202:c903:d:7ce9",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uva-9-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.131.9"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.131.9",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -117,10 +134,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "megaraid_sas",
       "interface": "SAS",
       "model": "PERC 6/i",
       "rev": 1.22,
-      "size": 146163105792
+      "size": 146163105792,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -128,7 +147,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uva/uva.json
+++ b/data/grid5000/sites/sophia/clusters/uva/uva.json
@@ -3,7 +3,7 @@
   "kavlan": true,
   "model": "Dell PowerEdge R900",
   "queues": [
-    "default",
+    "testing",
     "admin"
   ],
   "type": "cluster",

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-1.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-1.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:38:b9",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c6:11",
       "interface": "InfiniBand",
       "ip": "172.18.132.1",
       "ip6": "fe80::224:e890:97ff:c611",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-1-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c6:11",
       "interface": "InfiniBand",
       "ip": "172.18.132.1",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-1-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.1"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.1",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-10.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-10.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:3e:e9",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:58:49",
       "interface": "InfiniBand",
       "ip": "172.18.132.10",
       "ip6": "fe80::224:e890:97ff:5849",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-10-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:58:49",
       "interface": "InfiniBand",
       "ip": "172.18.132.10",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-10-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.10"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.10",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-11.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-11.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:33:29",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:af:24",
       "interface": "InfiniBand",
       "ip": "172.18.132.11",
       "ip6": "fe80::224:e890:97ff:af24",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-11-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:af:24",
       "interface": "InfiniBand",
       "ip": "172.18.132.11",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-11-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.11"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.11",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-12.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-12.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:3c:d1",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:ad:fc",
       "interface": "InfiniBand",
       "ip": "172.18.132.12",
       "ip6": "fe80::224:e890:97ff:adfc",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-12-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:ad:fc",
       "interface": "InfiniBand",
       "ip": "172.18.132.12",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-12-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.12"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.12",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-13.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-13.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f0:13:65",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:14:fe:b5:90:97:fe:d0:cd",
       "interface": "InfiniBand",
       "ip": "172.18.132.13",
       "ip6": "fe80::16fe:b590:97fe:d0cd",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-13-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:14:fe:b5:90:97:fe:d0:cd",
       "interface": "InfiniBand",
       "ip": "172.18.132.13",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-13-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.13"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.13",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-14.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-14.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:5d:6d",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:8a:9d",
       "interface": "InfiniBand",
       "ip": "172.18.132.14",
       "ip6": "fe80::224:e890:97ff:8a9d",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-14-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:8a:9d",
       "interface": "InfiniBand",
       "ip": "172.18.132.14",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-14-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.14"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.14",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-15.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-15.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:2d:79",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:8a:cd",
       "interface": "InfiniBand",
       "ip": "172.18.132.15",
       "ip6": "fe80::224:e890:97ff:8acd",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-15-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:8a:cd",
       "interface": "InfiniBand",
       "ip": "172.18.132.15",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-15-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.15"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.15",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-16.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-16.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:2f:c5",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:57:c9",
       "interface": "InfiniBand",
       "ip": "172.18.132.16",
       "ip6": "fe80::224:e890:97ff:57c9",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-16-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:57:c9",
       "interface": "InfiniBand",
       "ip": "172.18.132.16",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-16-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.16"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.16",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-17.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-17.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:31:d5",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c5:21",
       "interface": "InfiniBand",
       "ip": "172.18.132.17",
       "ip6": "fe80::224:e890:97ff:c521",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-17-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c5:21",
       "interface": "InfiniBand",
       "ip": "172.18.132.17",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-17-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.17"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.17",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-18.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-18.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:3e:65",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c6:39",
       "interface": "InfiniBand",
       "ip": "172.18.132.18",
       "ip6": "fe80::224:e890:97ff:c639",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-18-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c6:39",
       "interface": "InfiniBand",
       "ip": "172.18.132.18",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-18-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.18"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.18",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-19.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-19.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:36:ed",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c4:f1",
       "interface": "InfiniBand",
       "ip": "172.18.132.19",
       "ip6": "fe80::224:e890:97ff:c4f1",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-19-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c4:f1",
       "interface": "InfiniBand",
       "ip": "172.18.132.19",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-19-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.19"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.19",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-2.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-2.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:36:91",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c6:71",
       "interface": "InfiniBand",
       "ip": "172.18.132.2",
       "ip6": "fe80::224:e890:97ff:c671",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-2-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c6:71",
       "interface": "InfiniBand",
       "ip": "172.18.132.2",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-2-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.2"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.2",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-20.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-20.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:3d:e9",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c6:1d",
       "interface": "InfiniBand",
       "ip": "172.18.132.20",
       "ip6": "fe80::224:e890:97ff:c61d",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-20-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c6:1d",
       "interface": "InfiniBand",
       "ip": "172.18.132.20",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-20-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.20"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.20",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-21.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-21.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:5b:4d",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:ad:f0",
       "interface": "InfiniBand",
       "ip": "172.18.132.21",
       "ip6": "fe80::224:e890:97ff:adf0",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-21-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:ad:f0",
       "interface": "InfiniBand",
       "ip": "172.18.132.21",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-21-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.21"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.21",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-22.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-22.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:31:29",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:8a:91",
       "interface": "InfiniBand",
       "ip": "172.18.132.22",
       "ip6": "fe80::224:e890:97ff:8a91",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-22-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:8a:91",
       "interface": "InfiniBand",
       "ip": "172.18.132.22",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-22-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.22"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.22",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-23.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-23.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:36:49",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:59:e1",
       "interface": "InfiniBand",
       "ip": "172.18.132.23",
       "ip6": "fe80::224:e890:97ff:59e1",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-23-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:59:e1",
       "interface": "InfiniBand",
       "ip": "172.18.132.23",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-23-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.23"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.23",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-24.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-24.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:2d:15",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:8a:8d",
       "interface": "InfiniBand",
       "ip": "172.18.132.24",
       "ip6": "fe80::224:e890:97ff:8a8d",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-24-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:8a:8d",
       "interface": "InfiniBand",
       "ip": "172.18.132.24",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-24-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.24"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.24",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-25.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-25.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:32:89",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:af:68",
       "interface": "InfiniBand",
       "ip": "172.18.132.25",
       "ip6": "fe80::224:e890:97ff:af68",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-25-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:af:68",
       "interface": "InfiniBand",
       "ip": "172.18.132.25",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-25-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.25"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.25",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-26.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-26.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:35:89",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c4:e5",
       "interface": "InfiniBand",
       "ip": "172.18.132.26",
       "ip6": "fe80::224:e890:97ff:c4e5",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-26-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c4:e5",
       "interface": "InfiniBand",
       "ip": "172.18.132.26",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-26-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.26"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.26",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-27.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-27.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:3e:ed",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c5:15",
       "interface": "InfiniBand",
       "ip": "172.18.132.27",
       "ip6": "fe80::224:e890:97ff:c515",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-27-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c5:15",
       "interface": "InfiniBand",
       "ip": "172.18.132.27",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-27-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.27"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.27",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-28.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-28.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:2e:d5",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:af:6c",
       "interface": "InfiniBand",
       "ip": "172.18.132.28",
       "ip6": "fe80::224:e890:97ff:af6c",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-28-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:af:6c",
       "interface": "InfiniBand",
       "ip": "172.18.132.28",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-28-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.28"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.28",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-29.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-29.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:3c:55",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:ad:ec",
       "interface": "InfiniBand",
       "ip": "172.18.132.29",
       "ip6": "fe80::224:e890:97ff:adec",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-29-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:ad:ec",
       "interface": "InfiniBand",
       "ip": "172.18.132.29",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-29-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.29"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.29",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-3.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-3.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:fb:8a:2d",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c6:0d",
       "interface": "InfiniBand",
       "ip": "172.18.132.3",
       "ip6": "fe80::224:e890:97ff:c60d",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-3-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c6:0d",
       "interface": "InfiniBand",
       "ip": "172.18.132.3",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-3-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.3"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.3",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-30.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-30.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:2e:c1",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:8a:99",
       "interface": "InfiniBand",
       "ip": "172.18.132.30",
       "ip6": "fe80::224:e890:97ff:8a99",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-30-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:8a:99",
       "interface": "InfiniBand",
       "ip": "172.18.132.30",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-30-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.30"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.30",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-31.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-31.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:32:39",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:af:20",
       "interface": "InfiniBand",
       "ip": "172.18.132.31",
       "ip6": "fe80::224:e890:97ff:af20",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-31-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:af:20",
       "interface": "InfiniBand",
       "ip": "172.18.132.31",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-31-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.31"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.31",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-32.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-32.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f3:2e:b1",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:a1:c8",
       "interface": "InfiniBand",
       "ip": "172.18.132.32",
       "ip6": "fe80::224:e890:97ff:a1c8",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-32-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:a1:c8",
       "interface": "InfiniBand",
       "ip": "172.18.132.32",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-32-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.32"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.32",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-33.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-33.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:31:21",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:af:1c",
       "interface": "InfiniBand",
       "ip": "172.18.132.33",
       "ip6": "fe80::224:e890:97ff:af1c",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-33-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:af:1c",
       "interface": "InfiniBand",
       "ip": "172.18.132.33",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-33-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.33"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.33",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-34.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-34.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:5e:41",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:59:b9",
       "interface": "InfiniBand",
       "ip": "172.18.132.34",
       "ip6": "fe80::224:e890:97ff:59b9",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-34-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:59:b9",
       "interface": "InfiniBand",
       "ip": "172.18.132.34",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-34-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.34"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.34",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-35.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-35.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:31:31",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:8a:95",
       "interface": "InfiniBand",
       "ip": "172.18.132.35",
       "ip6": "fe80::224:e890:97ff:8a95",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-35-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:8a:95",
       "interface": "InfiniBand",
       "ip": "172.18.132.35",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-35-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.35"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.35",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-36.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-36.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:3f:b9",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:57:d5",
       "interface": "InfiniBand",
       "ip": "172.18.132.36",
       "ip6": "fe80::224:e890:97ff:57d5",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-36-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:57:d5",
       "interface": "InfiniBand",
       "ip": "172.18.132.36",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-36-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.36"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.36",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-37.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-37.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:2f:15",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:af:50",
       "interface": "InfiniBand",
       "ip": "172.18.132.37",
       "ip6": "fe80::224:e890:97ff:af50",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-37-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:af:50",
       "interface": "InfiniBand",
       "ip": "172.18.132.37",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-37-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.37"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.37",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-38.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-38.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:2e:31",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c4:d9",
       "interface": "InfiniBand",
       "ip": "172.18.132.38",
       "ip6": "fe80::224:e890:97ff:c4d9",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-38-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c4:d9",
       "interface": "InfiniBand",
       "ip": "172.18.132.38",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-38-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.38"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.38",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-39.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-39.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:58:1d",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:ae:00",
       "interface": "InfiniBand",
       "ip": "172.18.132.39",
       "ip6": "fe80::224:e890:97ff:ae00",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-39-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:ae:00",
       "interface": "InfiniBand",
       "ip": "172.18.132.39",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-39-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.39"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.39",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-4.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-4.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:2d:c5",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c6:2d",
       "interface": "InfiniBand",
       "ip": "172.18.132.4",
       "ip6": "fe80::224:e890:97ff:c62d",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-4-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c6:2d",
       "interface": "InfiniBand",
       "ip": "172.18.132.4",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-4-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.4"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.4",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-40.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-40.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:30:9d",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:ad:dc",
       "interface": "InfiniBand",
       "ip": "172.18.132.40",
       "ip6": "fe80::224:e890:97ff:addc",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-40-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:ad:dc",
       "interface": "InfiniBand",
       "ip": "172.18.132.40",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-40-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.40"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.40",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-41.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-41.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:35:7d",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c4:e9",
       "interface": "InfiniBand",
       "ip": "172.18.132.41",
       "ip6": "fe80::224:e890:97ff:c4e9",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-41-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c4:e9",
       "interface": "InfiniBand",
       "ip": "172.18.132.41",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-41-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.41"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.41",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-42.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-42.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:3d:05",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c6:29",
       "interface": "InfiniBand",
       "ip": "172.18.132.42",
       "ip6": "fe80::224:e890:97ff:c629",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-42-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c6:29",
       "interface": "InfiniBand",
       "ip": "172.18.132.42",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-42-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.42"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.42",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-43.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-43.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:58:29",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:ad:e8",
       "interface": "InfiniBand",
       "ip": "172.18.132.43",
       "ip6": "fe80::224:e890:97ff:ade8",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-43-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:ad:e8",
       "interface": "InfiniBand",
       "ip": "172.18.132.43",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-43-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.43"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.43",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-44.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-44.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:33:39",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c6:7d",
       "interface": "InfiniBand",
       "ip": "172.18.132.44",
       "ip6": "fe80::224:e890:97ff:c67d",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-44-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c6:7d",
       "interface": "InfiniBand",
       "ip": "172.18.132.44",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-44-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.44"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.44",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-5.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-5.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:58:71",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:59:41",
       "interface": "InfiniBand",
       "ip": "172.18.132.5",
       "ip6": "fe80::224:e890:97ff:5941",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-5-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:59:41",
       "interface": "InfiniBand",
       "ip": "172.18.132.5",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-5-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.5"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.5",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-6.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-6.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:33:d1",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c6:15",
       "interface": "InfiniBand",
       "ip": "172.18.132.6",
       "ip6": "fe80::224:e890:97ff:c615",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-6-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c6:15",
       "interface": "InfiniBand",
       "ip": "172.18.132.6",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-6-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.6"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.6",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-7.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-7.json
@@ -44,34 +44,47 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:39:01",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "interface": "InfiniBand",
       "ip": "172.18.132.7",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-7-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "interface": "InfiniBand",
       "ip": "172.18.132.7",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-7-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.7"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.7",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -98,10 +111,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -109,7 +124,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-8.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-8.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:3a:15",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c6:69",
       "interface": "InfiniBand",
       "ip": "172.18.132.8",
       "ip6": "fe80::224:e890:97ff:c669",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-8-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:c6:69",
       "interface": "InfiniBand",
       "ip": "172.18.132.8",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-8-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.8"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.8",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-9.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/nodes/uvb-9.json
@@ -44,37 +44,50 @@
     {
       "device": "eth1",
       "driver": "igb",
+      "enabled": false,
       "interface": "Ethernet",
       "mac": "00:26:6c:f8:3e:9d",
       "management": false,
+      "mountable": false,
       "mounted": false
     },
     {
       "device": "ib0.8100",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:af:18",
       "interface": "InfiniBand",
       "ip": "172.18.132.9",
       "ip6": "fe80::224:e890:97ff:af18",
       "management": false,
+      "mountable": true,
       "mounted": true,
+      "network_address": "uvb-9-ib0.8100.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "ib0",
       "driver": "mlx4_core",
+      "enabled": true,
       "guid": "20:00:55:00:41:80:00:00:00:00:00:00:00:24:e8:90:97:ff:af:18",
       "interface": "InfiniBand",
       "ip": "172.18.132.9",
       "management": false,
+      "mountable": true,
       "mounted": false,
+      "network_address": "uvb-9-ib0.sophia.grid5000.fr",
       "rate": 40000000000,
       "version": "MT26428"
     },
     {
       "device": "bmc",
-      "ip": "172.17.132.9"
+      "enabled": true,
+      "interface": "Ethernet",
+      "ip": "172.17.132.9",
+      "management": false,
+      "mountable": false,
+      "mounted": false
     }
   ],
   "operating_system": {
@@ -101,10 +114,12 @@
   "storage_devices": [
     {
       "device": "sda",
+      "driver": "ahci",
       "interface": "SATA",
       "model": "WDC WD2502ABYS-1",
       "rev": 3.0,
-      "size": 250000000000
+      "size": 250000000000,
+      "storage": "HDD"
     }
   ],
   "supported_job_types": {
@@ -112,7 +127,7 @@
     "deploy": true,
     "max_walltime": 0,
     "queues": [
-      "default",
+      "testing",
       "admin"
     ],
     "virtual": "ivt"

--- a/data/grid5000/sites/sophia/clusters/uvb/uvb.json
+++ b/data/grid5000/sites/sophia/clusters/uvb/uvb.json
@@ -3,7 +3,7 @@
   "kavlan": true,
   "model": "Dell C6100",
   "queues": [
-    "default",
+    "testing",
     "admin"
   ],
   "type": "cluster",

--- a/input/grid5000/sites/sophia/clusters/uva/uva.yaml
+++ b/input/grid5000/sites/sophia/clusters/uva/uva.yaml
@@ -3,7 +3,7 @@ model: Dell PowerEdge R900
 created_at: 2016-07-01
 kavlan: true
 queues:
-    - default
+    - testing
     - admin
 
 nodes:
@@ -23,7 +23,7 @@ nodes:
       deploy: true
       besteffort: true
       queues:
-        - default
+        - testing
         - admin
       max_walltime: 0
     operating_system:

--- a/input/grid5000/sites/sophia/clusters/uva/uva.yaml
+++ b/input/grid5000/sites/sophia/clusters/uva/uva.yaml
@@ -40,6 +40,27 @@ nodes:
         enabled: true
         mountable: true
         bridged: true
+      eth1:
+        enabled: false
+        mountable: false
+      eth2:
+        enabled: false
+        mountable: false
+      eth3:
+        enabled: false
+        mountable: false
+      ib0:
+        enabled: true
+        mountable: true
+      ib0.8100:
+        enabled: true
+        mountable: true
+      bmc:
+        interface: Ethernet
+        enabled: true
+        mountable: false
+        mounted: false
+        management: false
     storage_devices:
       sda:
         interface: SAS

--- a/input/grid5000/sites/sophia/clusters/uva/uva.yaml
+++ b/input/grid5000/sites/sophia/clusters/uva/uva.yaml
@@ -64,3 +64,5 @@ nodes:
     storage_devices:
       sda:
         interface: SAS
+        driver: megaraid_sas
+        storage: HDD

--- a/input/grid5000/sites/sophia/clusters/uvb/uvb.yaml
+++ b/input/grid5000/sites/sophia/clusters/uvb/uvb.yaml
@@ -40,6 +40,21 @@ nodes:
         enabled: true
         mountable: true
         bridged: true
+      eth1:
+        enabled: false
+        mountable: false
+      ib0:
+        enabled: true
+        mountable: true
+      ib0.8100:
+        enabled: true
+        mountable: true
+      bmc:
+        interface: Ethernet
+        enabled: true
+        mountable: false
+        mounted: false
+        management: false
     storage_devices:
       sda:
         interface: SATA

--- a/input/grid5000/sites/sophia/clusters/uvb/uvb.yaml
+++ b/input/grid5000/sites/sophia/clusters/uvb/uvb.yaml
@@ -3,7 +3,7 @@ model: Dell C6100
 created_at: 2016-07-01
 kavlan: true
 queues:
-    - default
+    - testing
     - admin
 
 nodes:
@@ -23,7 +23,7 @@ nodes:
       deploy: true
       besteffort: true
       queues:
-        - default
+        - testing
         - admin
       max_walltime: 0
     operating_system:

--- a/input/grid5000/sites/sophia/clusters/uvb/uvb.yaml
+++ b/input/grid5000/sites/sophia/clusters/uvb/uvb.yaml
@@ -58,3 +58,5 @@ nodes:
     storage_devices:
       sda:
         interface: SATA
+        driver: ahci
+        storage: HDD


### PR DESCRIPTION
This fix errors related to eth1, eth2, eth3, bmc and storage (driver and type)

Also change the queues from **default** to **testing**
