### PR TITLE
network_equipments input schema validation

### DIFF
--- a/generators/input-validators/lib/custom_validators.rb
+++ b/generators/input-validators/lib/custom_validators.rb
@@ -1,0 +1,27 @@
+
+class HashValidator::Validator::LinecardPortValidator < HashValidator::Validator::Base
+
+  def initialize
+    super('linecard_port')
+    @port_properties = ["uid", "name", "port", "kind", "mtu", "rate", "site"]
+  end
+
+  def validate(key, values, validations, errors)
+    if values.is_a?(Hash)
+      values.each do |k, v|
+        if @port_properties.index(k) == nil
+          errors[key] = "unexpected key '#{k}'."
+        end
+      end
+      if values["uid"].nil? || values["uid"].empty?
+        errors[key] = "port 'uid' property should be defined."
+      end
+    elsif values.is_a?(String) || values == nil
+      #Allow any string and nil values
+    else
+      errors[key] = "port definition should be either empty, a String or a Hash (with required 'uid' and #{@port_properties} allowed properties)."
+    end
+  end
+end
+
+HashValidator.append_validator(HashValidator::Validator::LinecardPortValidator.new)

--- a/generators/input-validators/lib/schema_validator.rb
+++ b/generators/input-validators/lib/schema_validator.rb
@@ -10,7 +10,7 @@ dir = Pathname(__FILE__).parent
 
 require 'json'
 require 'hash_validator' # https://github.com/jamesbrooks/hash_validator
-require "#{dir}/multihash_validator" # custom validator
+require "#{dir}/multihash_validator" # custom validator for <multi> array-like Hash support
 
 # Simple required_hash validator
 HashValidator.append_validator(HashValidator::Validator::SimpleValidator.new('required_hash', lambda { |v| v.is_a?(Hash) }))
@@ -40,13 +40,14 @@ end
 # Recursively replace hash containing '<multi>' by HashValidator::MultiHash objects
 def add_multihash_validator(h)
   h.each_with_object({}) { |(k,v),g|
+    v = add_multihash_validator(v) if (Hash === v)
     g[k] = if (Hash === v)
              if v.key?('<multi>')
                HashValidator::Validations::Multi.new(v['<multi>'])
              elsif v.key?('<optional_hash>')
                HashValidator.optional(v['<optional_hash>'])
              else
-               add_multihash_validator(v)
+               v
              end
            else
              v

--- a/generators/input-validators/lib/schema_validator.rb
+++ b/generators/input-validators/lib/schema_validator.rb
@@ -11,6 +11,7 @@ dir = Pathname(__FILE__).parent
 require 'json'
 require 'hash_validator' # https://github.com/jamesbrooks/hash_validator
 require "#{dir}/multihash_validator" # custom validator for <multi> array-like Hash support
+require "#{dir}/custom_validators" # other custom validators
 
 # Simple required_hash validator
 HashValidator.append_validator(HashValidator::Validator::SimpleValidator.new('required_hash', lambda { |v| v.is_a?(Hash) }))

--- a/generators/input-validators/schema-network_equipments.yaml
+++ b/generators/input-validators/schema-network_equipments.yaml
@@ -1,0 +1,48 @@
+---
+model: string
+kind: string
+site: string
+backplane_bps: optional_integer
+mtu: optional_integer
+snmp_community: string
+network_adapters: optional
+weathermap:
+  <optional_hash>:
+    use_cacti: string
+sensors:
+  <optional_hash>:
+    network:
+      <optional_hash>:
+        available: boolean
+        resolution: optional_integer
+        via: optional
+    power:
+      <optional_hash>:
+        available: boolean
+        resolution: optional_integer
+        via: optional
+          #   pdu:
+          #       uid: string
+          #       port: integer
+monitoring:
+  <optional_hash>:
+    wattmeter: optional
+    metric: optional_string
+vlans:
+  <optional_hash>:
+    <multi>:
+      <optional_hash>:
+        administrative: optional_boolean
+        name: optional_string
+        addresses: optional_array
+        mtu: optional_integer
+linecards:
+  <multi>:
+    snmp_pattern: string
+    kind: optional_string
+    rate: integer
+    model: optional_string
+    backplane_bps: optional_integer
+    port: optional_string
+    ports:
+      <multi>: linecard_port #custom linecard port validation (see lib/custom-validators.rb)

--- a/generators/input-validators/yaml-input-schema-validator.rb
+++ b/generators/input-validators/yaml-input-schema-validator.rb
@@ -30,6 +30,7 @@ def yaml_input_schema_validator(global_hash, sites = nil, clusters = nil)
   schema_site    = load_yaml_schema("#{dir}/schema-site.yaml")
   schema_cluster = load_yaml_schema("#{dir}/schema-cluster.yaml")
   schema_node    = load_yaml_schema("#{dir}/schema-node.yaml")
+  schema_network_equipments = load_yaml_schema("#{dir}/schema-network_equipments.yaml")
 
   r = true
 
@@ -40,9 +41,13 @@ def yaml_input_schema_validator(global_hash, sites = nil, clusters = nil)
 
     r &= run_validator(site_uid, site, schema_site) #
 
-    site["clusters"].each do |cluster_uid, cluster|
-      next if clusters and not clusters.include?(cluster_uid)
+    site['networks'].each do |network_equipment_uid, network_equipment|
+      r &= run_validator(site_uid, network_equipment, schema_network_equipments)
+    end
 
+    site["clusters"].each do |cluster_uid, cluster|
+      next if clusters and not clusters.include?(cluster_uid)      
+      
       r &= run_validator(cluster_uid, cluster, schema_cluster) #
 
       cluster["nodes"].each do |node_uid, node|

--- a/generators/reference-api/reference-api.rb
+++ b/generators/reference-api/reference-api.rb
@@ -320,9 +320,7 @@ end
 
 # rename entry for the all-in-on json file
 global_hash["sites"].each do |site_uid, site|
-  site["networks"].sort.each do |network_uid, network|
-    site["network_equipments"] = site.delete("networks") 
-  end
+  site["network_equipments"] = site.delete("networks")
 end
 
 write_json(grid_path.join("../../#{global_hash['uid']}-all.json"), global_hash)

--- a/input/grid5000/sites/grenoble/networks/gw-grenoble.yaml
+++ b/input/grid5000/sites/grenoble/networks/gw-grenoble.yaml
@@ -10,9 +10,7 @@ gw-grenoble:
     network:
       available: true
       resolution: 1
-  routes: {}
   vlans:
-    naming_pattern: Vlan%VLANID%
     "vlan100":
       administrative: yes
       addresses:
@@ -65,7 +63,6 @@ gw-grenoble:
         - 10.7.192.0/18
   linecards:
     2:
-      naming_pattern: "%LINECARD%:%PORT%"
       snmp_pattern: "BD-8810 Port %LINECARD%:%PORT%"
       backplane_bps: 48000000000
       kind: switch
@@ -112,7 +109,6 @@ gw-grenoble:
         24:
           uid: voltaire-2
     3:
-      naming_pattern: "%LINECARD%:%PORT%"
       snmp_pattern: "BD-8810 Port %LINECARD%:%PORT%"
       kind: node
       backplane_bps: 48000000000
@@ -228,7 +224,6 @@ gw-grenoble:
           uid: genepi-2
           port: eth1
     4:
-      naming_pattern: "%LINECARD%:%PORT%"
       snmp_pattern: "BD-8810 Port %LINECARD%:%PORT%"
       backplane_bps: 48000000000
       kind: node
@@ -323,7 +318,6 @@ gw-grenoble:
           uid: grimage-8
           port: eth0
     10:
-      naming_pattern: "%LINECARD%:%PORT%"
       snmp_pattern: "BD-8810 Port %LINECARD%:%PORT%"
       backplane_bps: 48000000000
       kind: other
@@ -337,5 +331,3 @@ gw-grenoble:
           kind: virtual
           uid: renater-grenoble
           rate: 10000000000
-  channels:
-    naming_pattern: Po%CHANNELID%

--- a/input/grid5000/sites/grenoble/networks/ib-grenoble.yaml
+++ b/input/grid5000/sites/grenoble/networks/ib-grenoble.yaml
@@ -6,18 +6,12 @@ ib-grenoble:
   snmp_community: public
   weathermap: 
     use_cacti: "no"
-  vlans: 
-    naming_pattern: Vlan%VLANID%
-  routes: {}
-
+  vlans: {}
   linecards: 
-    0: 
-      naming_pattern: "%LINECARD%/%PORT%"
+    0:
       kind: switch
       rate: 10000000000
       ports: 
         0: voltaire-1
         1: voltaire-2
         2: voltaire-3
-  channels: 
-    naming_pattern: Po%CHANNELID%

--- a/input/grid5000/sites/grenoble/networks/sw-edel-1.yaml
+++ b/input/grid5000/sites/grenoble/networks/sw-edel-1.yaml
@@ -11,13 +11,9 @@ sw-edel-1:
   mtu: 9216
   weathermap: 
     use_cacti: "no"
-  vlans: 
-    naming_pattern: Vlan%VLANID%
-  routes: {}
-
+  vlans: {}
   linecards:
     1:
-      naming_pattern: "%LINECARD%/0/%PORT%"
       snmp_pattern: "Unit: %LINECARD% Slot: 0 Port: %PORT% Gigabit - Level"
       kind: node
       rate: 1000000000
@@ -55,5 +51,3 @@ sw-edel-1:
           uid: gw-grenoble
           port: "2:6"
           kind: router
-  channels: 
-    naming_pattern: Po%CHANNELID%

--- a/input/grid5000/sites/grenoble/networks/sw-edel-2.yaml
+++ b/input/grid5000/sites/grenoble/networks/sw-edel-2.yaml
@@ -11,13 +11,9 @@ sw-edel-2:
   mtu: 9216
   weathermap: 
     use_cacti: "no"
-  vlans: 
-    naming_pattern: Vlan%VLANID%
-  routes: {}
-
+  vlans: {}
   linecards: 
     1: 
-      naming_pattern: "%LINECARD%/0/%PORT%"
       snmp_pattern: "Unit: %LINECARD% Slot: 0 Port: %PORT% Gigabit - Level"
       kind: node
       rate: 1000000000
@@ -55,5 +51,3 @@ sw-edel-2:
           uid: gw-grenoble
           port: "2:3"
           kind: router
-  channels: 
-    naming_pattern: Po%CHANNELID%

--- a/input/grid5000/sites/grenoble/networks/sw-edel-3.yaml
+++ b/input/grid5000/sites/grenoble/networks/sw-edel-3.yaml
@@ -11,13 +11,9 @@ sw-edel-3:
   mtu: 9216
   weathermap: 
     use_cacti: "no"
-  vlans: 
-    naming_pattern: Vlan%VLANID%
-  routes: {}
-
+  vlans: {}
   linecards: 
     1: 
-      naming_pattern: "%LINECARD%/0/%PORT%"
       snmp_pattern: "Unit: %LINECARD% Slot: 0 Port: %PORT% Gigabit - Level"
       kind: node
       rate: 1000000000
@@ -55,5 +51,3 @@ sw-edel-3:
           uid: gw-grenoble
           port: "2:9"
           kind: router
-  channels: 
-    naming_pattern: Po%CHANNELID%

--- a/input/grid5000/sites/grenoble/networks/sw-edel-4.yaml
+++ b/input/grid5000/sites/grenoble/networks/sw-edel-4.yaml
@@ -11,13 +11,9 @@ sw-edel-4:
   mtu: 9216
   weathermap: 
     use_cacti: "no"
-  vlans: 
-    naming_pattern: Vlan%VLANID%
-  routes: {}
-
+  vlans: {}
   linecards: 
     1:
-      naming_pattern: "%LINECARD%/0/%PORT%"
       snmp_pattern: "Unit: %LINECARD% Slot: 0 Port: %PORT% Gigabit - Level"
       kind: node
       rate: 1000000000
@@ -55,5 +51,3 @@ sw-edel-4:
           uid: gw-grenoble
           port: "2:12"
           kind: router
-  channels: 
-    naming_pattern: Po%CHANNELID%

--- a/input/grid5000/sites/grenoble/networks/voltaire-1.yaml
+++ b/input/grid5000/sites/grenoble/networks/voltaire-1.yaml
@@ -6,16 +6,10 @@ voltaire-1:
   snmp_community: public
   weathermap: 
     use_cacti: "no"
-  vlans: 
-    naming_pattern: Vlan%VLANID%
-  routes: {}
-
-  linecards: 
+  vlans: {}
+  linecards:
     0: 
-      naming_pattern: "%LINECARD%/%PORT%"
       kind: switch
       rate: 10000000000
       ports: 
-        0: ib-grenoble 
-  channels: 
-    naming_pattern: Po%CHANNELID%
+        0: ib-grenoble

--- a/input/grid5000/sites/grenoble/networks/voltaire-2.yaml
+++ b/input/grid5000/sites/grenoble/networks/voltaire-2.yaml
@@ -6,16 +6,10 @@ voltaire-2:
   snmp_community: public
   weathermap: 
     use_cacti: "no"
-  vlans: 
-    naming_pattern: Vlan%VLANID%
-  routes: {}
-
+  vlans: {}
   linecards: 
     0: 
-      naming_pattern: "%LINECARD%/%PORT%"
       kind: switch
       rate: 10000000000
       ports: 
         0: ib-grenoble
-  channels: 
-    naming_pattern: Po%CHANNELID%

--- a/input/grid5000/sites/grenoble/networks/voltaire-3.yaml
+++ b/input/grid5000/sites/grenoble/networks/voltaire-3.yaml
@@ -6,16 +6,10 @@ voltaire-3:
   snmp_community: public
   weathermap: 
     use_cacti: "no"
-  vlans: 
-    naming_pattern: Vlan%VLANID%
-  routes: {}
-
+  vlans: {}
   linecards: 
-    0: 
-      naming_pattern: "%LINECARD%/%PORT%"
+    0:
       kind: switch
       rate: 10000000000
       ports: 
         0: ib-grenoble
-  channels: 
-    naming_pattern: Po%CHANNELID%

--- a/input/grid5000/sites/lille/networks/gw-lille.yaml
+++ b/input/grid5000/sites/lille/networks/gw-lille.yaml
@@ -8,11 +8,9 @@ gw-lille:
     network:
       available: true
       resolution: 1
-  routes: {}
   backplane_bps: 720000000000
   mtu: 9216
   vlans:
-    naming_pattern: Vlan%VLANID%
     "vlan100":
       administrative: yes
       addresses:
@@ -72,11 +70,9 @@ gw-lille:
       name: kavlan-12
       addresses:
         - 10.11.192.0/18
-
   linecards:
     6:
       kind: router
-      naming_pattern: Gi%LINECARD%/%PORT%
       snmp_pattern: GigabitEthernet%LINECARD%/%PORT%
       backplane_bps: 40000000000
       rate: 1000000000
@@ -84,7 +80,6 @@ gw-lille:
         2: interco-NR-Lille
     1:
       kind: virtual
-      naming_pattern: Te%LINECARD%/%PORT%
       snmp_pattern: TenGigabitEthernet%LINECARD%/%PORT%
       backplane_bps: 40000000000
       rate: 10000000000
@@ -92,7 +87,6 @@ gw-lille:
         1: renater-lille
     2:
       kind: node
-      naming_pattern: Gi%LINECARD%/%PORT%
       snmp_pattern: GigabitEthernet%LINECARD%/%PORT%
       backplane_bps: 40000000000
       rate: 1000000000
@@ -145,7 +139,6 @@ gw-lille:
 
     3:
       kind: node
-      naming_pattern: Gi%LINECARD%/%PORT%
       snmp_pattern: GigabitEthernet%LINECARD%/%PORT%
       backplane_bps: 40000000000
       rate: 1000000000
@@ -220,7 +213,6 @@ gw-lille:
             port: eth1
     4:
       kind: node
-      naming_pattern: Gi%LINECARD%/%PORT%
       snmp_pattern: GigabitEthernet%LINECARD%/%PORT%
       backplane_bps: 40000000000
       rate: 1000000000
@@ -261,6 +253,3 @@ gw-lille:
         35: chinqchint-35
         37: chinqchint-37
         38: chinqchint-38
-  channels:
-    naming_pattern: Po%CHANNELID%
-    snmp_pattern: Port-channel%CHANNELID%

--- a/input/grid5000/sites/lille/networks/myrinet.yaml
+++ b/input/grid5000/sites/lille/networks/myrinet.yaml
@@ -4,10 +4,7 @@ myrinet:
   kind: switch
   site: lille
   snmp_community: public
-  routes: {}
-
   vlans:
-    naming_pattern: Vlan%VLANID%
     "vlan103":
       administrative: yes
       addresses:
@@ -15,10 +12,6 @@ myrinet:
   linecards:
     0:
       kind: router
-      naming_pattern: Gi%LINECARD%/%PORT%
       rate: 1000000000
       ports:
         1: gw-lille
-  channels:
-    naming_pattern: Po%CHANNELID%
-

--- a/input/grid5000/sites/luxembourg/networks/gw-luxembourg.yaml
+++ b/input/grid5000/sites/luxembourg/networks/gw-luxembourg.yaml
@@ -11,7 +11,6 @@ gw-luxembourg:
   backplane_bps: 720000000000
   mtu: 9216
   vlans:
-    naming_pattern: Vlan%VLANID%
     "vlan50":
       addresses:
         - 192.168.15.254
@@ -68,11 +67,8 @@ gw-luxembourg:
       name: kavlan-20
       addresses:
         - 10.43.192.0/18
-  routes: {}
-
   linecards:
     1:
-      naming_pattern: Gi%LINECARD%/%PORT%
       snmp_pattern: GigabitEthernet%LINECARD%/%PORT%
       backplane_bps: 40000000000
       rate: 1000000000
@@ -225,7 +221,6 @@ gw-luxembourg:
 #          kind: switch
         48:
     2:
-      naming_pattern: Gi%LINECARD%/%PORT%
       snmp_pattern: GigabitEthernet%LINECARD%/%PORT%
       backplane_bps: 40000000000
       rate: 1000000000
@@ -344,7 +339,6 @@ gw-luxembourg:
           kind: other
         48:
     3:
-      naming_pattern: Te%LINECARD%/%PORT%
       snmp_pattern: TenGigabitEthernet%LINECARD%/%PORT%
       rate: 10000000000
       backplane_bps: 40000000000
@@ -357,7 +351,6 @@ gw-luxembourg:
           uid: ul-grid5000-sw02
           port: Ethernet1/32
     5:
-      naming_pattern: Te%LINECARD%/%PORT%
       snmp_pattern: TenGigabitEthernet%LINECARD%/%PORT%
       rate: 1000000000
       backplane_bps: 40000000000
@@ -366,26 +359,3 @@ gw-luxembourg:
         4:
           uid: renater-luxembourg
           rate: 10000000000
-  channels:
-    naming_pattern: Po%CHANNELID%
-    snmp_pattern: Port-channel%CHANNELID%
-    "lacp1":
-        - linecard: 1
-          port: 35
-        - linecard: 2
-          port: 44
-    "lacp2":
-        - linecard: 1
-          port: 36
-        - linecard: 1
-          port: 40
-    "lacp3":
-        - linecard: 1
-          port: 23
-        - linecard: 2
-          port: 46
-    "lacp4":
-        - linecard: 3
-          port: 1
-        - linecard: 3
-          port: 2

--- a/input/grid5000/sites/luxembourg/networks/mxl1.yaml
+++ b/input/grid5000/sites/luxembourg/networks/mxl1.yaml
@@ -13,16 +13,12 @@ mxl1:
   weathermap:
     use_cacti: "yes"
   vlans:
-    naming_pattern: Vlan%VLANID%
     "vlan101":
       administrative: yes
       addresses:
         - 172.17.191.251
-  routes: {}
-
   linecards:
     0:
-      naming_pattern: "Te%LINECARD%/%PORT%"
       snmp_pattern: "TenGigabitEthernet %LINECARD%/%PORT%"
       rate: 10000000000
       kind: node
@@ -91,15 +87,3 @@ mxl1:
           uid: ul-grid5000-sw02
           port: Ethernet1/36
           kind: switch
-  channels:
-    naming_pattern: Po%CHANNELID%
-    snmp_pattern: Port-channel%CHANNELID%
-    "lacp5":
-        - linecard: 1
-          port: 33
-        - linecard: 1
-          port: 34
-        - linecard: 1
-          port: 35
-        - linecard: 1
-          port: 36

--- a/input/grid5000/sites/luxembourg/networks/mxl2.yaml
+++ b/input/grid5000/sites/luxembourg/networks/mxl2.yaml
@@ -13,16 +13,12 @@ mxl2:
   weathermap:
     use_cacti: "yes"
   vlans:
-    naming_pattern: Vlan%VLANID%
     "vlan101":
       administrative: yes
       addresses:
         - 172.17.191.252
-  routes: {}
-
   linecards:
     0:
-      naming_pattern: "Te%LINECARD%/%PORT%"
       snmp_pattern: "TenGigabitEthernet %LINECARD%/%PORT%"
       rate: 10000000000
       kind: node
@@ -91,15 +87,3 @@ mxl2:
           uid: ul-grid5000-sw02
           port: Ethernet1/40
           kind: switch
-  channels:
-    naming_pattern: Po%CHANNELID%
-    snmp_pattern: Port-channel%CHANNELID%
-    "lacp6":
-        - linecard: 1
-          port: 33
-        - linecard: 1
-          port: 34
-        - linecard: 1
-          port: 35
-        - linecard: 1
-          port: 36

--- a/input/grid5000/sites/luxembourg/networks/ul-grid5000-sw02.yaml
+++ b/input/grid5000/sites/luxembourg/networks/ul-grid5000-sw02.yaml
@@ -13,13 +13,10 @@ ul-grid5000-sw02:
   weathermap:
     use_cacti: "yes"
   vlans:
-    naming_pattern: Vlan%VLANID%
     "vlan101":
       administrative: yes
       addresses:
         - 172.17.191.253
-  routes: {}
-
   linecards:
 #    0:
 #      naming_pattern: "mgmt%PORT%"
@@ -30,7 +27,6 @@ ul-grid5000-sw02:
 #          port: Gi1/46
 #          kind: router
     1:
-      naming_pattern: "Ethernet%LINECARD%/%PORT%"
       snmp_pattern: "Ethernet%LINECARD%/%PORT%"
       rate: 10000000000
       kind: node
@@ -149,24 +145,3 @@ ul-grid5000-sw02:
           uid: mxl2
           port: Te0/36
           kind: switch
-  channels:
-    naming_pattern: Po%CHANNELID%
-    snmp_pattern: port-channel%CHANNELID%
-    "lacp5":
-        - linecard: 1
-          port: 33
-        - linecard: 1
-          port: 34
-        - linecard: 1
-          port: 35
-        - linecard: 1
-          port: 36
-    "lacp6":
-        - linecard: 1
-          port: 37
-        - linecard: 1
-          port: 38
-        - linecard: 1
-          port: 39
-        - linecard: 1
-          port: 40

--- a/input/grid5000/sites/lyon/networks/force10.yaml
+++ b/input/grid5000/sites/lyon/networks/force10.yaml
@@ -9,17 +9,14 @@ force10:
       available: true
       resolution: 1
   vlans:
-    naming_pattern: Vlan%VLANID%
     "vlan101":
       administrative: yes
       addresses:
         - 172.17.63.253
-  routes: {}
   backplane_bps: 1280000000000
   mtu: 12000
   linecards:
     0:
-      naming_pattern: "TenGigabitEthernet %LINECARD%/%PORT%"
       snmp_pattern: "TenGigabitEthernet %LINECARD%/%PORT%"
       kind: node
       rate: 10000000000
@@ -71,5 +68,3 @@ force10:
           uid: pat
           port: "1:25"
           kind: switch
-  channels:
-    naming_pattern: Po%CHANNELID%

--- a/input/grid5000/sites/lyon/networks/gw-lyon.yaml
+++ b/input/grid5000/sites/lyon/networks/gw-lyon.yaml
@@ -9,7 +9,6 @@ gw-lyon:
       available: true
       resolution: 1
   vlans:
-    naming_pattern: Vlan%VLANID%
     "vlan100":
       administrative: yes
       addresses:
@@ -60,12 +59,10 @@ gw-lyon:
       name: kavlan-13
       addresses:
         - 10.15.192.0/18
-  routes: {}
   backplane_bps: 800000000000
   mtu: 9216
   linecards:
     2:
-      naming_pattern: "%LINECARD%:%PORT%"
       snmp_pattern: "BD-8810 Port %LINECARD%:%PORT%"
       backplane_bps: 48000000000,
       kind: node
@@ -103,7 +100,6 @@ gw-lyon:
         31: sagittaire-79
         34: cyrrus-adm
     3:
-      naming_pattern: "%LINECARD%:%PORT%"
       snmp_pattern: "BD-8810 Port %LINECARD%:%PORT%"
       backplane_bps: 48000000000,
       kind: node
@@ -158,7 +154,6 @@ gw-lyon:
         8: sagittaire-8
         9: sagittaire-9
     4:
-      naming_pattern: "%LINECARD%:%PORT%"
       snmp_pattern: "BD-8810 Port %LINECARD%:%PORT%"
       backplane_bps: 48000000000,
       kind: switch
@@ -184,7 +179,6 @@ gw-lyon:
           uid: ENS-Lyon
           kind: virtual # Through castor, nat VM to ENS-Lyon network
     9:
-      naming_pattern: "%LINECARD%:%PORT%"
       snmp_pattern: "BD-8810 Port %LINECARD%:%PORT%"
       backplane_bps: 48000000000,
       kind: switch
@@ -200,5 +194,3 @@ gw-lyon:
           uid: renater-lyon
           site: renater
           kind: virtual
-  channels:
-    naming_pattern: Po%CHANNELID%

--- a/input/grid5000/sites/lyon/networks/pat.yaml
+++ b/input/grid5000/sites/lyon/networks/pat.yaml
@@ -12,17 +12,13 @@ pat:
     use_cacti: "no"
   mtu: 1500
   vlans:
-    naming_pattern: Vlan%VLANID%
     "vlan1":
       administrative: yes
       addresses:
         - 172.17.63.250
-  routes: {}
   backplane_bps: 40000000000
-
   linecards:
     1:
-      naming_pattern: "%LINECARD%/%PORT%"
       snmp_pattern: "EtherNet Port on unit %LINECARD%, port:%PORT%"
       kind: node
       rate: 100000000
@@ -59,5 +55,3 @@ pat:
           uid: chris
           port: "0:37"
           kind: switch
-  channels:
-    naming_pattern: Po%CHANNELID%

--- a/input/grid5000/sites/lyon/networks/salome.yaml
+++ b/input/grid5000/sites/lyon/networks/salome.yaml
@@ -10,28 +10,21 @@ salome:
       resolution: 1
   mtu: 10240
   vlans:
-    naming_pattern: Vlan%VLANID%
     "vlan101":
       administrative: yes
       addresses:
         - 172.17.63.252
-  routes: {}
   backplane_bps: 136000000000,
   linecards:
     0:
-      naming_pattern: "ethernet%PORT%"
       snmp_pattern: "GigabitEthernet%PORT%"
       kind: router
       rate: 1000000000
       ports:
         49:
             uid: gw-lyon
-            snmp_pattern: "GigabitEthernet%PORT%"
             rate: 10000000000
         48:
             uid: mizar
             port: eth0
             kind: other
-  channels:
-    naming_pattern: Po%CHANNELID%
-

--- a/input/grid5000/sites/nancy/networks/gw-nancy.yaml
+++ b/input/grid5000/sites/nancy/networks/gw-nancy.yaml
@@ -26,7 +26,6 @@ gw-nancy:
     metric: power
   mtu: 9220
   vlans:
-    naming_pattern: Vlan%VLANID%
     "vlan100":
       administrative: yes
       addresses:
@@ -77,11 +76,9 @@ gw-nancy:
       name: kavlan-14
       addresses:
         - 10.19.192.0/18
-  routes: {}
   backplane_bps: 1280000000000
   linecards:
     1:
-      naming_pattern: "E%LINECARD%/%PORT%"
       snmp_pattern: "Ethernet%LINECARD%/%PORT%"
       backplane_bps: 1280000000000
       model: N9K-X9464PX
@@ -221,7 +218,6 @@ gw-nancy:
           uid: renater-nancy
           kind: virtual
     2:
-      naming_pattern: "E%LINECARD%/%PORT%"
       snmp_pattern: "Ethernet%LINECARD%/%PORT%"
       backplane_bps: 1280000000000
       model: N9K-X9464PX
@@ -373,7 +369,6 @@ gw-nancy:
           uid: grimoire-8
           kind: node
     3:
-      naming_pattern: "E%LINECARD%/%PORT%"
       snmp_pattern: "Ethernet%LINECARD%/%PORT%"
       backplane_bps: 1280000000000
       model: N9K-X9464PX
@@ -573,7 +568,6 @@ gw-nancy:
           kind: node
           port: eth1
     4:
-      naming_pattern: "E%LINECARD%/%PORT%"
       snmp_pattern: "Ethernet%LINECARD%/%PORT%"
       backplane_bps: 1280000000000
       model: N9K-X9464PX
@@ -773,7 +767,6 @@ gw-nancy:
           kind: node
           port: eth2
     5:
-      naming_pattern: "E%LINECARD%/%PORT%"
       snmp_pattern: "Ethernet%LINECARD%/%PORT%"
       backplane_bps: 1280000000000
       model: N9K-X9464PX
@@ -973,7 +966,6 @@ gw-nancy:
           kind: node
           port: eth3
     6:
-      naming_pattern: "E%LINECARD%/%PORT%"
       snmp_pattern: "Ethernet%LINECARD%/%PORT%"
       backplane_bps: 1280000000000
       model: N9K-X9464PX

--- a/input/grid5000/sites/nancy/networks/sgraoullyib.yaml
+++ b/input/grid5000/sites/nancy/networks/sgraoullyib.yaml
@@ -19,13 +19,9 @@ sgraoullyib:
     metric: power
   weathermap:
     use_cacti: "no"
-  vlans:
-    naming_pattern: Vlan%VLANID%
-  routes: {}
-
+  vlans: {}
   linecards:
     12:
-      naming_pattern: "%LINECARD%/%PORT%"
       snmp_pattern: "%LINECARD%/%PORT%"
       kind: switch
       rate: 20000000000
@@ -33,5 +29,3 @@ sgraoullyib:
         12: 
           uid: sgriffonib
           kind: switch
-  channels:
-    naming_pattern: Po%CHANNELID%

--- a/input/grid5000/sites/nancy/networks/sgraphene1.yaml
+++ b/input/grid5000/sites/nancy/networks/sgraphene1.yaml
@@ -22,16 +22,13 @@ sgraphene1:
     metric: power
   mtu: 9216
   vlans:
-    naming_pattern: Vlan-interface%VLANID%
     "vlan1":
       administrative: yes
       addresses:
         - 172.16.79.201
-  routes: {}
   backplane_bps: 176000000000
   linecards:
     0:
-      naming_pattern: "GigabitEthernet1/%LINECARD%/%PORT%"
       snmp_pattern: "GigabitEthernet1/%LINECARD%/%PORT%"
       kind: node
       rate: 1000000000
@@ -76,7 +73,6 @@ sgraphene1:
         37: graphene-38
         40: graphene-39
     1:
-      naming_pattern: "Ten-GigabitEthernet1/%LINECARD%/%PORT%"
       snmp_pattern: "Ten-GigabitEthernet1/%LINECARD%/%PORT%"
       kind: switch
       rate: 10000000000
@@ -84,5 +80,3 @@ sgraphene1:
         2: 
           uid: sgravillon1
           kind: switch
-  channels:
-    naming_pattern: Po%CHANNELID%

--- a/input/grid5000/sites/nancy/networks/sgraphene2.yaml
+++ b/input/grid5000/sites/nancy/networks/sgraphene2.yaml
@@ -10,16 +10,13 @@ sgraphene2:
       resolution: 1
   mtu: 9216
   vlans:
-    naming_pattern: Vlan-interface%VLANID%
     "vlan1":
       administrative: yes
       addresses:
         - 172.16.79.202
-  routes: {}
   backplane_bps: 176000000000
   linecards:
     0:
-      naming_pattern: "GigabitEthernet1/%LINECARD%/%PORT%"
       snmp_pattern: "GigabitEthernet1/%LINECARD%/%PORT%"
       kind: node
       rate: 1000000000
@@ -60,7 +57,6 @@ sgraphene2:
         34: graphene-73
         35: graphene-74
     1:
-      naming_pattern: "Ten-GigabitEthernet1/%LINECARD%/%PORT%"
       snmp_pattern: "Ten-GigabitEthernet1/%LINECARD%/%PORT%"
       kind: switch
       rate: 10000000000
@@ -68,5 +64,3 @@ sgraphene2:
         2: 
           uid: sgravillon1
           kind: switch
-  channels:
-    naming_pattern: Po%CHANNELID%

--- a/input/grid5000/sites/nancy/networks/sgraphene3.yaml
+++ b/input/grid5000/sites/nancy/networks/sgraphene3.yaml
@@ -10,16 +10,13 @@ sgraphene3:
       resolution: 1
   mtu: 9216
   vlans:
-    naming_pattern: Vlan-interface%VLANID%
     "vlan1":
       administrative: yes
       addresses:
         - 172.16.79.203
-  routes: {}
   backplane_bps: 176000000000
   linecards:
     0:
-      naming_pattern: "GigabitEthernet1/%LINECARD%/%PORT%"
       snmp_pattern: "GigabitEthernet1/%LINECARD%/%PORT%"
       kind: node
       rate: 1000000000
@@ -55,7 +52,6 @@ sgraphene3:
         30: graphene-103
         29: graphene-104
     1:
-      naming_pattern: "Ten-GigabitEthernet1/%LINECARD%/%PORT%"
       snmp_pattern: "Ten-GigabitEthernet1/%LINECARD%/%PORT%"
       kind: switch
       rate: 10000000000
@@ -63,5 +59,3 @@ sgraphene3:
         2: 
           uid: sgravillon1
           kind: switch
-  channels:
-    naming_pattern: Po%CHANNELID%

--- a/input/grid5000/sites/nancy/networks/sgraphene4.yaml
+++ b/input/grid5000/sites/nancy/networks/sgraphene4.yaml
@@ -10,16 +10,13 @@ sgraphene4:
       resolution: 1
   mtu: 9216
   vlans:
-    naming_pattern: Vlan-interface%VLANID%
     "vlan1":
       administrative: yes
       addresses:
         - 172.16.79.204
-  routes: {}
   backplane_bps: 176000000000
   linecards:
     0:
-      naming_pattern: "GigabitEthernet1/%LINECARD%/%PORT%"
       snmp_pattern: "GigabitEthernet1/%LINECARD%/%PORT%"
       kind: node
       rate: 1000000000
@@ -65,7 +62,6 @@ sgraphene4:
         39: graphene-143
         40: graphene-144
     1:
-      naming_pattern: "Ten-GigabitEthernet1/%LINECARD%/%PORT%"
       snmp_pattern: "Ten-GigabitEthernet1/%LINECARD%/%PORT%"
       kind: switch
       rate: 10000000000
@@ -73,5 +69,3 @@ sgraphene4:
         1: 
           uid: sgravillon1
           kind: switch
-  channels:
-    naming_pattern: Po%CHANNELID%

--- a/input/grid5000/sites/nancy/networks/sgrapheneib.yaml
+++ b/input/grid5000/sites/nancy/networks/sgrapheneib.yaml
@@ -9,13 +9,9 @@ sgrapheneib:
       available: false
   weathermap:
     use_cacti: "no"
-  vlans:
-    naming_pattern: Vlan%VLANID%
-  routes: {}
-
+  vlans: {}
   linecards:
     12:
-      naming_pattern: "%LINECARD%/%PORT%"
       snmp_pattern: "%LINECARD%/%PORT%"
       kind: switch
       rate: 20000000000
@@ -23,5 +19,3 @@ sgrapheneib:
         12: 
           uid: sgriffonib
           kind: switch
-  channels:
-    naming_pattern: Po%CHANNELID%

--- a/input/grid5000/sites/nancy/networks/sgravillon1.yaml
+++ b/input/grid5000/sites/nancy/networks/sgravillon1.yaml
@@ -9,11 +9,9 @@ sgravillon1:
       available: true
       resolution: 1
   mtu: 9220
-  routes: {}
   backplane_bps: 346000000000
   linecards:
     1:
-      naming_pattern: "%LINECARD:A%%PORT%"
       snmp_pattern: "A%PORT%"
       backplane_bps: 14400000000
       model: J8702A
@@ -48,7 +46,6 @@ sgravillon1:
           uid: fgriffon1
           kind: other
     2:
-      naming_pattern: "%LINECARD:B%%PORT%"
       snmp_pattern: "B%PORT%"
       backplane_bps: 14400000000
       model: J8708A
@@ -57,7 +54,6 @@ sgravillon1:
       ports:
         1: sgriffon1
     3:
-      naming_pattern: "%LINECARD:C%%PORT%"
       snmp_pattern: "C%PORT%"
       backplane_bps: 14400000000
       model: J8708A
@@ -68,7 +64,6 @@ sgravillon1:
         2: sgraphene2
         4: sgraphene4
     4:
-      naming_pattern: "%LINECARD:D%%PORT%"
       snmp_pattern: "D%PORT%"
       backplane_bps: 14400000000
       model: J8708A
@@ -87,7 +82,6 @@ sgravillon1:
           uid: sgraphene3
           kind: switch
     6:
-      naming_pattern: "%LINECARD:F%%PORT%"
       snmp_pattern: "F%PORT%"
       backplane_bps: 14400000000
       model: J9538A
@@ -97,10 +91,3 @@ sgravillon1:
         1:
           uid: gw-nancy
           kind: router
-  channels:
-    naming_pattern: Po%CHANNELID%
-    snmp_pattern: Trk%CHANNELID%
-    "lacp3":
-        - linecard: 1
-          port: 11
-          port: 23

--- a/input/grid5000/sites/nancy/networks/sgriffon1.yaml
+++ b/input/grid5000/sites/nancy/networks/sgriffon1.yaml
@@ -22,16 +22,13 @@ sgriffon1:
     metric: power
   mtu: 9216
   vlans:
-    naming_pattern: Vlan-interface%VLANID%
     "vlan1":
       administrative: yes
       addresses:
         - 172.16.79.205
-  routes: {}
   backplane_bps: 176000000000
   linecards:
     0:
-      naming_pattern: "GigabitEthernet1/%LINECARD%/%PORT%"
       snmp_pattern: "GigabitEthernet1/%LINECARD%/%PORT%"
       kind: node
       rate: 1000000000
@@ -81,7 +78,6 @@ sgriffon1:
           uid: griffon-14
           port: eth1
     1:
-      naming_pattern: "Ten-GigabitEthernet1/%LINECARD%/%PORT%"
       snmp_pattern: "Ten-GigabitEthernet1/%LINECARD%/%PORT%"
       kind: other
       rate: 10000000000
@@ -89,6 +85,3 @@ sgriffon1:
         2: 
           uid: sgravillon1
           kind: switch
-
-  channels:
-    naming_pattern: Po%CHANNELID%

--- a/input/grid5000/sites/nancy/networks/stalc1.yaml
+++ b/input/grid5000/sites/nancy/networks/stalc1.yaml
@@ -10,16 +10,13 @@ stalc1:
       resolution: 1
   mtu: 9216
   vlans:
-    naming_pattern: Vlan-interface%VLANID%
     "vlan1":
       administrative: yes
       addresses:
         - 172.16.79.224
-  routes: {}
   backplane_bps: 176000000000
   linecards:
     0:
-      naming_pattern: "GigabitEthernet1/%LINECARD%/%PORT%"
       snmp_pattern: "GigabitEthernet1/%LINECARD%/%PORT%"
       kind: node
       rate: 1000000000
@@ -139,14 +136,12 @@ stalc1:
           uid: talc-37
           port: eth0
     1:
-      naming_pattern: "Ten-GigabitEthernet1/%LINECARD%/%PORT%"
       snmp_pattern: "Ten-GigabitEthernet1/%LINECARD%/%PORT%"
       kind: switch
       rate: 10000000000
       ports:
         2: stalc3
     2:
-      naming_pattern: "Ten-GigabitEthernet1/%LINECARD%/%PORT%"
       snmp_pattern: "Ten-GigabitEthernet1/%LINECARD%/%PORT%"
       kind: other
       rate: 10000000000
@@ -159,6 +154,3 @@ stalc1:
           rate: 10000000000
           uid: talc-srv
           port: eth2
-  channels:
-    naming_pattern: Po%CHANNELID%
-

--- a/input/grid5000/sites/nancy/networks/stalc2.yaml
+++ b/input/grid5000/sites/nancy/networks/stalc2.yaml
@@ -10,16 +10,13 @@ stalc2:
       resolution: 1
   mtu: 9216
   vlans:
-    naming_pattern: Vlan-interface%VLANID%
     "vlan1":
       administrative: yes
       addresses:
         - 172.16.79.225
-  routes: {}
   backplane_bps: 176000000000
   linecards:
     0:
-      naming_pattern: "GigabitEthernet1/%LINECARD%/%PORT%"
       snmp_pattern: "GigabitEthernet1/%LINECARD%/%PORT%"
       kind: node
       rate: 1000000000
@@ -115,7 +112,6 @@ stalc2:
           uid: talc-67
           port: eth0
     1:
-      naming_pattern: "Ten-GigabitEthernet1/%LINECARD%/%PORT%"
       snmp_pattern: "Ten-GigabitEthernet1/%LINECARD%/%PORT%"
       kind: switch
       rate: 10000000000
@@ -123,7 +119,6 @@ stalc2:
         1: stalc4
         2: stalc3
     2:
-      naming_pattern: "Ten-GigabitEthernet1/%LINECARD%/%PORT%"
       snmp_pattern: "Ten-GigabitEthernet1/%LINECARD%/%PORT%"
       kind: other
       rate: 10000000000
@@ -136,5 +131,3 @@ stalc2:
           port: eth2
           uid: ftalc2
           kind: other
-  channels:
-    naming_pattern: Po%CHANNELID%

--- a/input/grid5000/sites/nancy/networks/stalc3.yaml
+++ b/input/grid5000/sites/nancy/networks/stalc3.yaml
@@ -10,16 +10,13 @@ stalc3:
       resolution: 1
   mtu: 9216
   vlans:
-    naming_pattern: Vlan-interface%VLANID%
     "vlan1":
       administrative: yes
       addresses:
         - 172.16.79.226
-  routes: {}
   backplane_bps: 176000000000
   linecards:
     0:
-      naming_pattern: "GigabitEthernet1/%LINECARD%/%PORT%"
       snmp_pattern: "GigabitEthernet1/%LINECARD%/%PORT%"
       kind: node
       rate: 1000000000
@@ -139,12 +136,9 @@ stalc3:
           uid: talc-133
           port: eth0
     1:
-      naming_pattern: "Ten-GigabitEthernet1/%LINECARD%/%PORT%"
       snmp_pattern: "Ten-GigabitEthernet1/%LINECARD%/%PORT%"
       kind: switch
       rate: 10000000000
       ports:
         1: stalc1
         2: stalc2
-  channels:
-    naming_pattern: Po%CHANNELID%

--- a/input/grid5000/sites/nancy/networks/stalc4.yaml
+++ b/input/grid5000/sites/nancy/networks/stalc4.yaml
@@ -10,16 +10,13 @@ stalc4:
       resolution: 1
   mtu: 9216
   vlans:
-    naming_pattern: Vlan%VLANID%
     "vlan100":
       administrative: yes
       addresses:
         - 172.16.79.227
-  routes: {}
   backplane_bps: 176000000000
   linecards:
     0:
-      naming_pattern: "GigabitEthernet1/%LINECARD%/%PORT%"
       snmp_pattern: "GigabitEthernet1/%LINECARD%/%PORT%"
       kind: node
       rate: 1000000000
@@ -109,11 +106,8 @@ stalc4:
           uid: talc-132
           port: eth0
     1:
-      naming_pattern: "Ten-GigabitEthernet1/%LINECARD%/%PORT%"
       snmp_pattern: "Ten-GigabitEthernet1/%LINECARD%/%PORT%"
       kind: switch
       rate: 10000000000
       ports:
         1: stalc2
-  channels:
-    naming_pattern: Po%CHANNELID%

--- a/input/grid5000/sites/nantes/networks/gw-nantes.yaml
+++ b/input/grid5000/sites/nantes/networks/gw-nantes.yaml
@@ -9,7 +9,6 @@ gw-nantes:
       available: true
       resolution: 1
   vlans:
-    naming_pattern: Vlan%VLANID%
     "vlan100":
       administrative: yes
       addresses:
@@ -61,12 +60,10 @@ gw-nantes:
       name: kavlan-21
       addresses:
         - 10.47.192.0/18
-  routes: {}
   backplane_bps: 1280000000000
   mtu: 1500
   linecards:
     0:
-      naming_pattern: "TenGigabitEthernet %LINECARD%/%PORT%"
       snmp_pattern: "TenGigabitEthernet %LINECARD%/%PORT%"
       kind: node
       rate: 10000000000
@@ -98,6 +95,3 @@ gw-nantes:
         28: econome-20
         31: econome-21
         30: econome-22
-
-  channels:
-    naming_pattern: Po%CHANNELID%

--- a/input/grid5000/sites/rennes/networks/bigdata-sw.yaml
+++ b/input/grid5000/sites/rennes/networks/bigdata-sw.yaml
@@ -9,17 +9,14 @@ bigdata-sw:
       available: true
       resolution: 1
   vlans:
-    naming_pattern: Vlan%VLANID%
     "vlan101":
       administrative: yes
       addresses:
         - 172.17.111.203
-  routes: {}
   backplane_bps: 1280000000000
   mtu: 1500
   linecards:
     0:
-      naming_pattern: "TenGigabitEthernet %LINECARD%/%PORT%"
       snmp_pattern: "TenGigabitEthernet %LINECARD%/%PORT%"
       kind: node
       rate: 10000000000
@@ -52,5 +49,3 @@ bigdata-sw:
         45: paranoia-5
         46: paranoia-2
         47: paranoia-1
-  channels:
-    naming_pattern: Po%CHANNELID%

--- a/input/grid5000/sites/rennes/networks/c6509.yaml
+++ b/input/grid5000/sites/rennes/networks/c6509.yaml
@@ -13,7 +13,6 @@ c6509:
   linecards:
     1:
       kind: virtual
-      naming_pattern: Te%LINECARD%/%PORT%
       snmp_pattern: TenGigabitEthernet%LINECARD%/%PORT%
       rate: 10000000000
       backplane_bps: 40000000000
@@ -27,7 +26,6 @@ c6509:
           kind: switch
     2:
       kind: node
-      naming_pattern: Gi%LINECARD%/%PORT%
       snmp_pattern: GigabitEthernet%LINECARD%/%PORT%
       rate: 1000000000
       backplane_bps: 40000000000
@@ -60,7 +58,6 @@ c6509:
           port: eth2
     3:
       kind: node
-      naming_pattern: Gi%LINECARD%/%PORT%
       snmp_pattern: GigabitEthernet%LINECARD%/%PORT%
       rate: 1000000000
       backplane_bps: 40000000000
@@ -92,7 +89,6 @@ c6509:
           port: eth2
     8:
       kind: node
-      naming_pattern: Gi%LINECARD%/%PORT%
       snmp_pattern: GigabitEthernet%LINECARD%/%PORT%
       rate: 1000000000
       backplane_bps: 40000000000
@@ -101,7 +97,6 @@ c6509:
         16:
     7:
       kind: node
-      naming_pattern: Gi%LINECARD%/%PORT%
       snmp_pattern: GigabitEthernet%LINECARD%/%PORT%
       rate: 1000000000
       model: WS-X6748-GE-TX
@@ -121,7 +116,6 @@ c6509:
         41: parapide-9
     6:
       kind: node
-      naming_pattern: Gi%LINECARD%/%PORT%
       snmp_pattern: GigabitEthernet%LINECARD%/%PORT%
       rate: 1000000000
       backplane_bps: 40000000000
@@ -142,7 +136,6 @@ c6509:
         33: parapluie-33
     4:
       kind: node
-      naming_pattern: Gi%LINECARD%/%PORT%
       snmp_pattern: GigabitEthernet%LINECARD%/%PORT%
       rate: 1000000000
       backplane_bps: 40000000000
@@ -162,6 +155,3 @@ c6509:
         34: parapluie-38
         36: parapluie-39
         37: parapluie-40
-  channels:
-    naming_pattern: Po%CHANNELID%
-    snmp_pattern: Port-channel%CHANNELID%

--- a/input/grid5000/sites/rennes/networks/gw-rennes.yaml
+++ b/input/grid5000/sites/rennes/networks/gw-rennes.yaml
@@ -8,11 +8,9 @@ gw-rennes:
     network:
       available: true
       resolution: 10
-  routes: {}
   backplane_bps: 1440000000000
   mtu: 1500
   vlans:
-    naming_pattern: Vlan%VLANID%
     "vlan100":
       administrative: yes
       addresses:
@@ -64,10 +62,8 @@ gw-rennes:
       name: kavlan-16
       addresses:
         - 10.27.192.0/18
-  routes: {}
   linecards:
     1:
-      naming_pattern: "Ethernet%LINECARD%/%PORT%"
       snmp_pattern: "Ethernet%LINECARD%/%PORT%"
       rate: 10000000000
       ports:
@@ -280,7 +276,6 @@ gw-rennes:
           rate: 40000000000
           kind: switch
     2:
-      naming_pattern: "Ethernet%LINECARD%/%PORT%"
       snmp_pattern: "Ethernet%LINECARD%/%PORT%"
       rate: 10000000000
       ports:
@@ -322,20 +317,3 @@ gw-rennes:
         24:
           uid: renater-rennes
           kind: virtual
-  channels:
-    naming_pattern: Po%CHANNELID%
-    snmp_pattern: port-channel%CHANNELID%
-    2:
-      - linecard: 1
-        port: 51
-        rate: 40000000000
-      - linecard: 1
-        port: 52
-        rate: 40000000000
-    3:
-      - linecard: 1
-        port: 49
-        rate: 40000000000
-      - linecard: 1
-        port: 50
-        rate: 40000000000

--- a/input/grid5000/sites/rennes/networks/paravance-sw-1.yaml
+++ b/input/grid5000/sites/rennes/networks/paravance-sw-1.yaml
@@ -8,12 +8,10 @@ paravance-sw-1:
     network:
       available: true
       resolution: 1
-  routes: {}
   backplane_bps: 1440000000000
   mtu: 1500
   linecards:
     1:
-      naming_pattern: "Ethernet%LINECARD%/%PORT%"
       snmp_pattern: "Ethernet%LINECARD%/%PORT%"
       rate: 10000000000
       ports:
@@ -218,7 +216,6 @@ paravance-sw-1:
           rate: 40000000000
           kind: router
     2:
-      naming_pattern: "Ethernet%LINECARD%/%PORT%"
       snmp_pattern: "Ethernet%LINECARD%/%PORT%"
       rate: 10000000000
       ports:
@@ -318,13 +315,3 @@ paravance-sw-1:
           uid: paravance-36
           kind: node
           port: eth0
-  channels:
-    naming_pattern: Po%CHANNELID%
-    snmp_pattern: port-channel%CHANNELID%
-    2:
-      - linecard: 1
-        port: 49
-        rate: 40000000000
-      - linecard: 1
-        port: 50
-        rate: 40000000000

--- a/input/grid5000/sites/rennes/networks/paravance-sw-2.yaml
+++ b/input/grid5000/sites/rennes/networks/paravance-sw-2.yaml
@@ -8,12 +8,10 @@ paravance-sw-2:
     network:
       available: true
       resolution: 1
-  routes: {}
   backplane_bps: 1440000000000
   mtu: 1500
   linecards:
     1:
-      naming_pattern: "Ethernet%LINECARD%/%PORT%"
       snmp_pattern: "Ethernet%LINECARD%/%PORT%"
       rate: 10000000000
       ports:
@@ -218,7 +216,6 @@ paravance-sw-2:
           rate: 40000000000
           kind: router
     2:
-      naming_pattern: "Ethernet%LINECARD%/%PORT%"
       snmp_pattern: "Ethernet%LINECARD%/%PORT%"
       rate: 10000000000
       ports:
@@ -318,13 +315,3 @@ paravance-sw-2:
           uid: paravance-72
           kind: node
           port: eth0
-  channels:
-    naming_pattern: Po%CHANNELID%
-    snmp_pattern: port-channel%CHANNELID%
-    3:
-      - linecard: 1
-        port: 51
-        rate: 40000000000
-      - linecard: 1
-        port: 52
-        rate: 40000000000

--- a/input/grid5000/sites/sophia/networks/edgeiron.yaml
+++ b/input/grid5000/sites/sophia/networks/edgeiron.yaml
@@ -12,18 +12,13 @@ edgeiron:
     use_cacti: "no"
   mtu: 10240
   vlans:
-    naming_pattern: Vlan%VLANID%
-    snmp_pattern: v%VLANID%
     "vlan100":
       administrative: yes
       addresses:
         - 172.16.143.250
-  routes: {}
   backplane_bps: 40000000000
-
   linecards:
     0:
-      naming_pattern: "%LINECARD%/%PORT%"
       snmp_pattern: "GigabitEthernet%LINECARD%/%PORT%"
       kind: router
       rate: 1000000000
@@ -35,7 +30,6 @@ edgeiron:
           uid: gw-sophia
           port: ethernet2/2
     1:
-      naming_pattern: "%LINECARD%/%PORT%"
       snmp_pattern: "GigabitEthernet%LINECARD%/%PORT%"
       kind: node
       rate: 1000000000
@@ -85,7 +79,6 @@ edgeiron:
         18: 
         21: 
     3:
-      naming_pattern: "%LINECARD%/%PORT%"
       snmp_pattern: "GigabitEthernet%LINECARD%/%PORT%"
       kind: node
       rate: 1000000000
@@ -101,6 +94,4 @@ edgeiron:
         8: 
         7: 
         6: 
-        5: 
-  channels:
-    naming_pattern: Po%CHANNELID%
+        5:

--- a/input/grid5000/sites/sophia/networks/gw-sophia.yaml
+++ b/input/grid5000/sites/sophia/networks/gw-sophia.yaml
@@ -10,8 +10,6 @@ gw-sophia:
       resolution: 1
   mtu: 10240
   vlans:
-    naming_pattern: Vlan%VLANID%
-    snmp_pattern: v%VLANID%
     "vlan100":
       administrative: yes
       addresses:
@@ -77,12 +75,9 @@ gw-sophia:
       name: kavlan-18
       addresses:
         - 10.35.192.0/18
-  routes: {}
   backplane_bps: 900000000000
-
   linecards:
     1:
-      naming_pattern: "ethernet%LINECARD%/%PORT%"
       snmp_pattern: "10GigabitEthernet%LINECARD%/%PORT%"
       kind: switch
       backplane_bps:
@@ -93,7 +88,6 @@ gw-sophia:
           kind: renater
           site: virtual
     2:
-      naming_pattern: "ethernet%LINECARD%/%PORT%"
       snmp_pattern: "10GigabitEthernet%LINECARD%/%PORT%"
       kind: switch
       backplane_bps: 20000000000
@@ -106,7 +100,6 @@ gw-sophia:
           uid: edgeiron
           port: 0/2
     7:
-      naming_pattern: "ethernet%LINECARD%/%PORT%"
       snmp_pattern: "GigabitEthernet%LINECARD%/%PORT%"
       kind: node
       backplane_bps: 24000000000
@@ -135,7 +128,6 @@ gw-sophia:
           port: eth1
           kind: other
     3:
-      naming_pattern: "ethernet%LINECARD%/%PORT%"
       snmp_pattern: "GigabitEthernet%LINECARD%/%PORT%"
       kind: node
       backplane_bps: 24000000000
@@ -166,7 +158,6 @@ gw-sophia:
         22: sol-35
         24: sol-36
     4:
-      naming_pattern: "ethernet%LINECARD%/%PORT%"
       snmp_pattern: "GigabitEthernet%LINECARD%/%PORT%"
       kind: node
       backplane_bps: 24000000000
@@ -197,7 +188,6 @@ gw-sophia:
         22: sol-47
         24: sol-48
     9:
-      naming_pattern: "ethernet%LINECARD%/%PORT%"
       snmp_pattern: "GigabitEthernet%LINECARD%/%PORT%"
       kind: other
       backplane_bps: 12000000000
@@ -217,7 +207,6 @@ gw-sophia:
           uid: stock
           port: eth1
     5:
-      naming_pattern: "ethernet%LINECARD%/%PORT%"
       snmp_pattern: "GigabitEthernet%LINECARD%/%PORT%"
       kind: node
       backplane_bps: 24000000000
@@ -241,7 +230,6 @@ gw-sophia:
         21: suno-16
         15: suno-17
     6:
-      naming_pattern: "ethernet%LINECARD%/%PORT%"
       snmp_pattern: "GigabitEthernet%LINECARD%/%PORT%"
       kind: node
       backplane_bps: 24000000000
@@ -289,5 +277,3 @@ gw-sophia:
           uid: srv-stock
           port: eth1
           kind: other
-  channels:
-    naming_pattern: Po%CHANNELID%


### PR DESCRIPTION
Schema validation for the network equipments with custom hash_validator extension for the linecard ports.
I've also corrected a problem which caused the 'network_equipments' property to be included in grid5000-all.json only if there was a single equipment.