### PR TITLE
[rennes] remove ceph from rennes.yaml

### DIFF
--- a/input/grid5000/sites/rennes/rennes.yaml
+++ b/input/grid5000/sites/rennes/rennes.yaml
@@ -16,12 +16,6 @@ storage5k: true
 production: true
 frontend_ip: 172.16.111.106
 
-# needed by puppet generators
-servers:
-  ceph:
-    nodes:
-      ceph[0-3]:
-
 g5ksubnet:
   network: 10.156.0.0/14
   gateway: 10.159.255.254


### PR DESCRIPTION
i remove ceph from rennes.yaml for match with test_refapi
error: 
---
rennes:
  servers:
    ceph:
      kind: 'string required (current value: NilClass:)'
      network_adapters: _multihash required
---